### PR TITLE
Feature/update responsible entities

### DIFF
--- a/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
+++ b/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using AutoFixture;
 using FluentAssertions;
 using Hackney.Shared.PatchesAndAreas.Domain;
@@ -45,7 +46,9 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
 
             var ResEnts2 = new List<ResponsibleEntities> { ResEnt2 };
 
-            ResEnt1.Should().BeEquivalentTo(ResEnt2);
+            ResEnts1.FirstOrDefault().Should().BeEquivalentTo(ResEnts2.FirstOrDefault());
+            ResEnts2.FirstOrDefault().Should().BeEquivalentTo(ResEnts1.FirstOrDefault());
+            ResEnts1.Should().BeEquivalentTo(ResEnts2);
 
         }
         [Fact]
@@ -62,7 +65,10 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
 
             var ResEnts2 = new List<ResponsibleEntities> { ResEnt2 };
 
-            ResEnt1.Should().NotBeEquivalentTo(ResEnt2);
+            ResEnts1.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts2.FirstOrDefault());
+            ResEnts2.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts1.FirstOrDefault());
+
+            ResEnts1.Should().NotBeEquivalentTo(ResEnts2);
 
         }
     }

--- a/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
+++ b/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
@@ -89,15 +89,15 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
                 .With(resEnt => resEnt.Id, testId)
                 .With(resEnt => resEnt.Name, testName1)
                 .Create();
-            
+
             var ResEnt2 = _fixture.Build<ResponsibleEntities>()
                 .With(resEnt => resEnt.Id, testId)
                 .With(resEnt => resEnt.Name, testName2)
                 .Create();
-            
+
             var ResEnts1 = new List<ResponsibleEntities> { ResEnt1 };
             var ResEnts2 = new List<ResponsibleEntities> { ResEnt2 };
-            
+
             ResEnts1.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts2.FirstOrDefault());
             ResEnts2.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts1.FirstOrDefault());
             ResEnts1.Should().NotBeEquivalentTo(ResEnts2);

--- a/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
+++ b/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using AutoFixture;
+using FluentAssertions;
+using Hackney.Shared.PatchesAndAreas.Domain;
+using Xunit;
+
+namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
+{
+    public class ResponsibleEntitiesTests
+    {
+        private readonly ResponsibleEntities _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+
+        public ResponsibleEntitiesTests()
+        {
+            _classUnderTest = new ResponsibleEntities();
+        }
+
+        [Fact]
+        public void EntitiesShouldBeEqualIfIdsMatch()
+        {
+            var testId = Guid.NewGuid();
+            var ResEnt1 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, testId)
+                .Create();
+            var ResEnt2 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, testId)
+                .Create();
+
+            ResEnt1.Should().BeEquivalentTo(ResEnt2);
+        }
+
+        [Fact]
+        public void PatchResponsibleEntitiesShouldBeEqualIfIdsMatch()
+        {
+            var testId = Guid.NewGuid();
+            var ResEnt1 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, testId)
+                .Create();
+            var ResEnt2 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, testId)
+                .Create();
+            var ResEnts1 = new List<ResponsibleEntities> { ResEnt1 };
+
+            var ResEnts2 = new List<ResponsibleEntities> { ResEnt2 };
+
+            ResEnt1.Should().BeEquivalentTo(ResEnt2);
+
+        }
+    }
+}

--- a/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
+++ b/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
@@ -48,5 +48,22 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
             ResEnt1.Should().BeEquivalentTo(ResEnt2);
 
         }
+        [Fact]
+        public void PatchResponsibleEntitiesShouldNotBeEqualIfIdsDoNotMatch()
+        {
+            var testId = Guid.NewGuid();
+            var ResEnt1 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, testId)
+                .Create();
+            var ResEnt2 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, Guid.NewGuid())
+                .Create();
+            var ResEnts1 = new List<ResponsibleEntities> { ResEnt1 };
+
+            var ResEnts2 = new List<ResponsibleEntities> { ResEnt2 };
+
+            ResEnt1.Should().NotBeEquivalentTo(ResEnt2);
+
+        }
     }
 }

--- a/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
+++ b/Hackney.Shared.PatchesAndAreas.Tests/Domain/ResponsibleEntitiesTests.cs
@@ -19,31 +19,36 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
         }
 
         [Fact]
-        public void EntitiesShouldBeEqualIfIdsMatch()
+        public void EntitiesShouldBeEqualIfIdsAndNamesMatch()
         {
             var testId = Guid.NewGuid();
+            var testName = "TEST_first TEST_last";
             var ResEnt1 = _fixture.Build<ResponsibleEntities>()
                 .With(resEnt => resEnt.Id, testId)
+                .With(resEnt => resEnt.Name, testName)
                 .Create();
             var ResEnt2 = _fixture.Build<ResponsibleEntities>()
                 .With(resEnt => resEnt.Id, testId)
+                .With(resEnt => resEnt.Name, testName)
                 .Create();
 
             ResEnt1.Should().BeEquivalentTo(ResEnt2);
         }
 
         [Fact]
-        public void PatchResponsibleEntitiesShouldBeEqualIfIdsMatch()
+        public void ResponsibleEntityListsShouldBeEqualIfIdsAndNamesMatch()
         {
             var testId = Guid.NewGuid();
+            var testName = "TEST_first TEST_last";
             var ResEnt1 = _fixture.Build<ResponsibleEntities>()
                 .With(resEnt => resEnt.Id, testId)
+                .With(resEnt => resEnt.Name, testName)
                 .Create();
             var ResEnt2 = _fixture.Build<ResponsibleEntities>()
                 .With(resEnt => resEnt.Id, testId)
+                .With(resEnt => resEnt.Name, testName)
                 .Create();
             var ResEnts1 = new List<ResponsibleEntities> { ResEnt1 };
-
             var ResEnts2 = new List<ResponsibleEntities> { ResEnt2 };
 
             ResEnts1.FirstOrDefault().Should().BeEquivalentTo(ResEnts2.FirstOrDefault());
@@ -52,14 +57,18 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
 
         }
         [Fact]
-        public void PatchResponsibleEntitiesShouldNotBeEqualIfIdsDoNotMatch()
+        public void ResponsibleEntityListsShouldNotBeEqualIfIdsDoNotMatch()
         {
             var testId = Guid.NewGuid();
+            var testid2 = Guid.NewGuid();
+            var testName = "TEST_first TEST_last";
             var ResEnt1 = _fixture.Build<ResponsibleEntities>()
                 .With(resEnt => resEnt.Id, testId)
+                .With(resEnt => resEnt.Name, testName)
                 .Create();
             var ResEnt2 = _fixture.Build<ResponsibleEntities>()
-                .With(resEnt => resEnt.Id, Guid.NewGuid())
+                .With(resEnt => resEnt.Id, testid2)
+                .With(resEnt => resEnt.Name, testName)
                 .Create();
             var ResEnts1 = new List<ResponsibleEntities> { ResEnt1 };
 
@@ -67,9 +76,31 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Domain
 
             ResEnts1.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts2.FirstOrDefault());
             ResEnts2.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts1.FirstOrDefault());
-
             ResEnts1.Should().NotBeEquivalentTo(ResEnts2);
+        }
 
+        [Fact]
+        public void ResponsibleEntityListsShouldNotBeEqualIfNamesDoNotMatch()
+        {
+            var testId = Guid.NewGuid();
+            var testName1 = "TEST_first TEST_last";
+            var testName2 = "TEST_first TEST_last2";
+            var ResEnt1 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, testId)
+                .With(resEnt => resEnt.Name, testName1)
+                .Create();
+            
+            var ResEnt2 = _fixture.Build<ResponsibleEntities>()
+                .With(resEnt => resEnt.Id, testId)
+                .With(resEnt => resEnt.Name, testName2)
+                .Create();
+            
+            var ResEnts1 = new List<ResponsibleEntities> { ResEnt1 };
+            var ResEnts2 = new List<ResponsibleEntities> { ResEnt2 };
+            
+            ResEnts1.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts2.FirstOrDefault());
+            ResEnts2.FirstOrDefault().Should().NotBeEquivalentTo(ResEnts1.FirstOrDefault());
+            ResEnts1.Should().NotBeEquivalentTo(ResEnts2);
         }
     }
 }

--- a/Hackney.Shared.PatchesAndAreas/Domain/ResponsibleEntities.cs
+++ b/Hackney.Shared.PatchesAndAreas/Domain/ResponsibleEntities.cs
@@ -14,11 +14,9 @@ namespace Hackney.Shared.PatchesAndAreas.Domain
 
         public override bool Equals(object other)
         {
-            ResponsibleEntities otherItem = other as ResponsibleEntities;
-
-            if (otherItem == null)
+            if (!(other is ResponsibleEntities otherItem))
                 throw new ArgumentNullException();
-            var isEqual = (Id == otherItem.Id);
+            var isEqual = (Id == otherItem.Id && Name == otherItem.Name);
             return isEqual;
         }
     }

--- a/Hackney.Shared.PatchesAndAreas/Domain/ResponsibleEntities.cs
+++ b/Hackney.Shared.PatchesAndAreas/Domain/ResponsibleEntities.cs
@@ -11,5 +11,22 @@ namespace Hackney.Shared.PatchesAndAreas.Domain
         public string Name { get; set; }
         public ResponsibleType ResponsibleType { get; set; }
         public ResponsibleEntityContactDetails ContactDetails { get; set; }
+
+        public override bool Equals(object other)
+        {
+            ResponsibleEntities otherItem = other as ResponsibleEntities;
+
+            if (otherItem == null)
+                throw new ArgumentNullException();
+            var isEqual = (Id == otherItem.Id);
+            return isEqual;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 13;
+            hash = (hash * 7) + Id.GetHashCode();
+            return hash;
+        }
     }
 }

--- a/Hackney.Shared.PatchesAndAreas/Domain/ResponsibleEntities.cs
+++ b/Hackney.Shared.PatchesAndAreas/Domain/ResponsibleEntities.cs
@@ -21,12 +21,5 @@ namespace Hackney.Shared.PatchesAndAreas.Domain
             var isEqual = (Id == otherItem.Id);
             return isEqual;
         }
-
-        public override int GetHashCode()
-        {
-            int hash = 13;
-            hash = (hash * 7) + Id.GetHashCode();
-            return hash;
-        }
     }
 }


### PR DESCRIPTION
Add method to override Equals() so that the id values can be compared to ensure there is a difference in the object being sent to the PUT responsibleEntities endpoint in patches and areas API.