### PR TITLE
Fix build and test fail

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-shared-patches-and-areas-test
+        run: docker compose build hackney-shared-patches-and-areas-test
       - name: Run tests
-        run: docker-compose run hackney-shared-patches-and-areas-test
+        run: docker compose run hackney-shared-patches-and-areas-test
 
   publish-package:
     name: Publish Package


### PR DESCRIPTION

The `docker-compose`command is failing in the [pipeline](https://github.com/LBHackney-IT/patches-and-areas-shared/actions/runs/10401756054/job/28807522648), but looks like it passes when I use `docker compose` instead. See this [issue thread](https://github.com/orgs/community/discussions/116610#discussioncomment-8997411).