### PR TITLE
Revert flag that will not be used for tidiness

### DIFF
--- a/Hackney.Shared.PatchesAndAreas.Tests/Factories/EntityFactoryTest.cs
+++ b/Hackney.Shared.PatchesAndAreas.Tests/Factories/EntityFactoryTest.cs
@@ -16,7 +16,6 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Factories
         {
             //Arrange
             var databaseEntity = _fixture.Create<PatchesDb>();
-            databaseEntity.IsDisabled = true;
             //Act
             var entity = databaseEntity.ToDomain();
             //Assert
@@ -25,7 +24,6 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Factories
             databaseEntity.ParentId.Should().Be(entity.ParentId);
             databaseEntity.PatchType.Should().Be(entity.PatchType);
             databaseEntity.ResponsibleEntities.Should().BeEquivalentTo(entity.ResponsibleEntities);
-            databaseEntity.IsDisabled.Should().Be(entity.IsDisabled);
         }
 
 
@@ -34,7 +32,6 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Factories
         {
             //Arrange
             var entity = _fixture.Create<PatchEntity>();
-            entity.IsDisabled = true;
             //Act
             var databaseEntity = entity.ToDatabase();
             //Assert
@@ -43,7 +40,6 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Factories
             entity.ParentId.Should().Be(databaseEntity.ParentId);
             entity.PatchType.Should().Be(databaseEntity.PatchType);
             entity.ResponsibleEntities.Should().BeEquivalentTo(databaseEntity.ResponsibleEntities);
-            entity.IsDisabled.Should().Be(databaseEntity.IsDisabled);
         }
     }
 }

--- a/Hackney.Shared.PatchesAndAreas.Tests/Factories/ResponseFactoryTest.cs
+++ b/Hackney.Shared.PatchesAndAreas.Tests/Factories/ResponseFactoryTest.cs
@@ -16,7 +16,6 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Factories
             //Arrange
             var domain = new PatchEntity();
             domain.ResponsibleEntities = new List<ResponsibleEntities>();
-            domain.IsDisabled = true;
             //Act
             var response = domain.ToResponse();
             //Assert
@@ -25,7 +24,6 @@ namespace Hackney.Shared.PatchesAndAreas.Tests.Factories
             domain.ParentId.Should().Be(response.ParentId);
             domain.PatchType.Should().Be(response.PatchType);
             domain.ResponsibleEntities.Should().BeEquivalentTo(response.ResponsibleEntities);
-            domain.IsDisabled.Should().Be(response.IsDisabled);
             domain.VersionNumber.Should().Be(response.VersionNumber);
         }
     }

--- a/Hackney.Shared.PatchesAndAreas/Boundary/Response/PatchesResponseObject.cs
+++ b/Hackney.Shared.PatchesAndAreas/Boundary/Response/PatchesResponseObject.cs
@@ -12,7 +12,6 @@ namespace Hackney.Shared.PatchesAndAreas.Boundary.Response
         public PatchType PatchType { get; set; }
         public string Domain { get; set; }
         public List<ResponsibleEntities> ResponsibleEntities { get; set; }
-        public bool IsDisabled { get; set; }
 
         public int? VersionNumber { get; set; }
 

--- a/Hackney.Shared.PatchesAndAreas/Domain/PatchEntity.cs
+++ b/Hackney.Shared.PatchesAndAreas/Domain/PatchEntity.cs
@@ -11,7 +11,6 @@ namespace Hackney.Shared.PatchesAndAreas.Domain
         public PatchType PatchType { get; set; }
         public string Domain { get; set; }
         public IEnumerable<ResponsibleEntities> ResponsibleEntities { get; set; }
-        public bool IsDisabled { get; set; }
         public int? VersionNumber { get; set; }
 
     }

--- a/Hackney.Shared.PatchesAndAreas/Factories/EntityFactory.cs
+++ b/Hackney.Shared.PatchesAndAreas/Factories/EntityFactory.cs
@@ -16,7 +16,6 @@ namespace Hackney.Shared.PatchesAndAreas.Factories
                 Domain = databaseEntity.Domain,
                 PatchType = databaseEntity.PatchType,
                 ResponsibleEntities = databaseEntity.ResponsibleEntities,
-                IsDisabled = databaseEntity.IsDisabled,
                 VersionNumber = databaseEntity.VersionNumber
             };
         }
@@ -34,7 +33,6 @@ namespace Hackney.Shared.PatchesAndAreas.Factories
                 Domain = entity.Domain,
                 PatchType = entity.PatchType,
                 ResponsibleEntities = entity.ResponsibleEntities.ToListOrEmpty(),
-                IsDisabled = entity.IsDisabled,
                 VersionNumber = entity.VersionNumber
             };
         }

--- a/Hackney.Shared.PatchesAndAreas/Factories/ResponseFactory.cs
+++ b/Hackney.Shared.PatchesAndAreas/Factories/ResponseFactory.cs
@@ -18,7 +18,6 @@ namespace Hackney.Shared.PatchesAndAreas.Factories
                 Domain = domain.Domain,
                 PatchType = domain.PatchType,
                 ResponsibleEntities = domain.ResponsibleEntities.ToListOrEmpty(),
-                IsDisabled = domain.IsDisabled,
                 VersionNumber = domain.VersionNumber
             };
         }

--- a/Hackney.Shared.PatchesAndAreas/Infrastructure/PatchesDb.cs
+++ b/Hackney.Shared.PatchesAndAreas/Infrastructure/PatchesDb.cs
@@ -28,9 +28,6 @@ namespace Hackney.Shared.PatchesAndAreas.Infrastructure
         [DynamoDBProperty(Converter = typeof(DynamoDbObjectListConverter<ResponsibleEntities>))]
         public List<ResponsibleEntities> ResponsibleEntities { get; set; }
 
-        [DynamoDBProperty]
-        public bool IsDisabled { get; set; }
-
         [DynamoDBVersion]
         public int? VersionNumber { get; set; }
 


### PR DESCRIPTION
This flag needs to go for now, as the current patches are not being replaced. 
It might be the case that in the future another location-related property will be added to the asset, but it will not be patch related.